### PR TITLE
chore: update Let's Encrypt staging environment

### DIFF
--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -90,7 +90,8 @@ resource "aws_instance" "jenkins_server" {
   }
 
   user_data = base64encode("${templatefile("../modules/ec2/userdata.sh", {
-    DOMAIN_NAME = "jenkins.${var.domain_name}"
+    DOMAIN_NAME = "jenkins.${var.domain_name}",
+    ENVIRONMENT = "${var.environment}"
   })}")
 
   tags = {

--- a/modules/ec2/userdata.sh
+++ b/modules/ec2/userdata.sh
@@ -1,18 +1,23 @@
 #!/bin/bash
 
 cd /etc/caddy/ || exit
-sudo mv Caddyfile Caddyfile.backup
+sudo mv Caddyfile Caddyfile.bkp
 touch Caddyfile
-echo "${DOMAIN_NAME}" >domain.txt
 
-tee -a ./Caddyfile <<END
-{
-    acme_ca https://acme-staging-v02.api.letsencrypt.org/directory
+if [ "$ENVIRONMENT" = "prod" ]; then
+  echo "${DOMAIN_NAME} {
+  root * /usr/share/caddy
+  reverse_proxy localhost:8080
+}" | tee ./Caddyfile
+else
+  echo "{
+  acme_ca https://acme-staging-v02.api.letsencrypt.org/directory
 }
 ${DOMAIN_NAME} {
   root * /usr/share/caddy
   reverse_proxy localhost:8080
-}
-END
+}" | tee ./Caddyfile
+
+fi
 
 sudo systemctl restart caddy.service

--- a/modules/ec2/variables.tf
+++ b/modules/ec2/variables.tf
@@ -6,3 +6,4 @@ variable "domain_name" {}
 variable "igw_id" {}
 variable "vpc_id" {}
 variable "ssh_key_name" {}
+variable "environment" {}

--- a/root/main.tf
+++ b/root/main.tf
@@ -23,4 +23,5 @@ module "ec2" {
   igw_id           = module.vpc.igw_id
   vpc_id           = module.vpc.vpc_id
   ssh_key_name     = module.ssh.ssh_key_name
+  environment      = var.env
 }


### PR DESCRIPTION
In order to avoid running into Let's Encrypt rate limits, the Caddyfile configuration now uses the Let's Encrypt staging environment as a reverse proxy server.